### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,90 +2,84 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.0.3](https://github.com/ulic75/flat-slider/compare/v0.0.2...v0.0.3) (2022-03-12)
+### [0.0.4](https://github.com/ulic75/flat-slider/compare/v0.0.3...v0.0.4) (2022-03-12)
 
+### Changes
+
+- correct issue with package.json exports
+
+### [0.0.3](https://github.com/ulic75/flat-slider/compare/v0.0.2...v0.0.3) (2022-03-12)
 
 ### Bug Fixes
 
-* **docs:** move text-nowrap to track-background ([6541470](https://github.com/ulic75/flat-slider/commit/654147042297915973931612945fa616382e4e4c))
-* **style:** allow any background styles instead of color only ([#7](https://github.com/ulic75/flat-slider/issues/7)) ([c5adb36](https://github.com/ulic75/flat-slider/commit/c5adb3663bea4014daca60d07e5b7373cfc15931))
+- **docs:** move text-nowrap to track-background ([6541470](https://github.com/ulic75/flat-slider/commit/654147042297915973931612945fa616382e4e4c))
+- **style:** allow any background styles instead of color only ([#7](https://github.com/ulic75/flat-slider/issues/7)) ([c5adb36](https://github.com/ulic75/flat-slider/commit/c5adb3663bea4014daca60d07e5b7373cfc15931))
 
 ### [0.0.2](https://github.com/ulic75/flat-slider/compare/v0.0.1...v0.0.2) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **docs:** use unpkg bundle file in demos ([#2](https://github.com/ulic75/flat-slider/issues/2)) ([2a4eb68](https://github.com/ulic75/flat-slider/commit/2a4eb68c84e5d1f591d087476391ca9b44ba35f2))
+- **docs:** use unpkg bundle file in demos ([#2](https://github.com/ulic75/flat-slider/issues/2)) ([2a4eb68](https://github.com/ulic75/flat-slider/commit/2a4eb68c84e5d1f591d087476391ca9b44ba35f2))
 
 ### [0.0.1](https://github.com/ulic75/flat-slider/compare/v0.0.0...v0.0.1) (2022-03-11)
 
-
 ### Bug Fixes
 
-* trigger initial release ([3354795](https://github.com/ulic75/flat-slider/commit/335479575fc5f350d0aa9df2955793da434dc0f1))
+- trigger initial release ([3354795](https://github.com/ulic75/flat-slider/commit/335479575fc5f350d0aa9df2955793da434dc0f1))
 
 ### [0.1.1](https://github.com/ulic75/flat-slider/compare/v0.1.0...v0.1.1) (2022-03-11)
 
-
 ### Bug Fixes
 
-* release-please ([02f3a2f](https://github.com/ulic75/flat-slider/commit/02f3a2f83f9a247cae3684a46f14a20869300809))
+- release-please ([02f3a2f](https://github.com/ulic75/flat-slider/commit/02f3a2f83f9a247cae3684a46f14a20869300809))
 
 ## [0.1.0](https://github.com/ulic75/flat-slider/compare/v0.0.3...v0.1.0) (2022-03-11)
 
-
 ### Features
 
-* deploy to pages ([2d7868d](https://github.com/ulic75/flat-slider/commit/2d7868dab6fddfe576be62649721b380f8b0456e))
+- deploy to pages ([2d7868d](https://github.com/ulic75/flat-slider/commit/2d7868dab6fddfe576be62649721b380f8b0456e))
 
 ### [0.0.3](https://github.com/ulic75/flat-slider/compare/v0.0.2...v0.0.3) (2022-03-11)
 
-
 ### Bug Fixes
 
-* release-please ([cdc6ce6](https://github.com/ulic75/flat-slider/commit/cdc6ce63b37e872c08d685206f4b5261f4abf853))
+- release-please ([cdc6ce6](https://github.com/ulic75/flat-slider/commit/cdc6ce63b37e872c08d685206f4b5261f4abf853))
 
 ### [0.0.2](https://github.com/ulic75/flat-slider/compare/v0.0.1...v0.0.2) (2022-03-11)
 
-
 ### Bug Fixes
 
-* release-please ([31896d7](https://github.com/ulic75/flat-slider/commit/31896d7332fb392361e74ffe2f27ca9607e71094))
-* update packages ([303903e](https://github.com/ulic75/flat-slider/commit/303903e7b1ab5215adf8743a31205cbea213e460))
+- release-please ([31896d7](https://github.com/ulic75/flat-slider/commit/31896d7332fb392361e74ffe2f27ca9607e71094))
+- update packages ([303903e](https://github.com/ulic75/flat-slider/commit/303903e7b1ab5215adf8743a31205cbea213e460))
 
 ### [0.0.1](https://github.com/ulic75/flat-slider/compare/v0.0.0...v0.0.1) (2022-03-11)
 
-
 ### Features
 
-* publish after release ([040a9dd](https://github.com/ulic75/flat-slider/commit/040a9dd3e03fb384de37e257617e6d78dd25d4da))
-
+- publish after release ([040a9dd](https://github.com/ulic75/flat-slider/commit/040a9dd3e03fb384de37e257617e6d78dd25d4da))
 
 ### Bug Fixes
 
-* **docs:** rename demos ([192973e](https://github.com/ulic75/flat-slider/commit/192973efe3d949aea7b9e076c66cc27e50473312))
-* **docs:** unrename demos ([cb2066c](https://github.com/ulic75/flat-slider/commit/cb2066c75e5618e942e102fd9d09174784e2ae18))
-* release-please ([7dce1d3](https://github.com/ulic75/flat-slider/commit/7dce1d3ddefdc934326fdae6c7a145db0e068b38))
-* **workflow:** remove package-name ([b5628a1](https://github.com/ulic75/flat-slider/commit/b5628a165767ebc7307e6c4ce788e141e02812b0))
+- **docs:** rename demos ([192973e](https://github.com/ulic75/flat-slider/commit/192973efe3d949aea7b9e076c66cc27e50473312))
+- **docs:** unrename demos ([cb2066c](https://github.com/ulic75/flat-slider/commit/cb2066c75e5618e942e102fd9d09174784e2ae18))
+- release-please ([7dce1d3](https://github.com/ulic75/flat-slider/commit/7dce1d3ddefdc934326fdae6c7a145db0e068b38))
+- **workflow:** remove package-name ([b5628a1](https://github.com/ulic75/flat-slider/commit/b5628a165767ebc7307e6c4ce788e141e02812b0))
 
 ## [1.2.0-alpha.7](https://github.com/ulic75/flat-slider/compare/v1.1.0-alpha.7...v1.2.0-alpha.7) (2022-03-11)
 
-
 ### Features
 
-* release-please ([299c79c](https://github.com/ulic75/flat-slider/commit/299c79c89ae86d0f0cf612aef8d6c19a2855208f))
+- release-please ([299c79c](https://github.com/ulic75/flat-slider/commit/299c79c89ae86d0f0cf612aef8d6c19a2855208f))
 
 ## [1.1.0-alpha.7](https://github.com/ulic75/flat-slider/compare/v1.0.0-alpha.7...v1.1.0-alpha.7) (2022-03-11)
 
-
 ### Features
 
-* demos ([a6de2c4](https://github.com/ulic75/flat-slider/commit/a6de2c4691840e94c3509a5fc8895538dcd99d00))
-
+- demos ([a6de2c4](https://github.com/ulic75/flat-slider/commit/a6de2c4691840e94c3509a5fc8895538dcd99d00))
 
 ### Bug Fixes
 
-* something ([8de8316](https://github.com/ulic75/flat-slider/commit/8de83161038f045871420fbfaa32bbd51bb3754a))
+- something ([8de8316](https://github.com/ulic75/flat-slider/commit/8de83161038f045871420fbfaa32bbd51bb3754a))
 
 ## [1.0.0-alpha.7](https://github.com/ulic75/flat-slider/compare/v1.0.0-alpha.6...v1.0.0-alpha.7) (2022-03-11)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: '&lt;flat-slider&gt;'
-subtitle: v0.0.3 # x-release-please-version
+subtitle: v0.0.4 # x-release-please-version
 email: ulic75@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   FlatSlider - A high configurable and stylable web-component range slider control.

--- a/docs/demos.html
+++ b/docs/demos.html
@@ -4,7 +4,7 @@ title: Demos
 ---
 <h1>&nbsp;</h1>
 <!-- x-release-please-start-version -->
-<script src="https://unpkg.com/@ulic75/flat-slider@0.0.3/dist/flat-slider.bundle.js" type="module"></script>
+<script src="https://unpkg.com/@ulic75/flat-slider@0.0.4/dist/flat-slider.bundle.js" type="module"></script>
 <!-- x-release-please-end -->
 <style>
   :root {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Webcomponent flat-slider following open-wc recommendations",
   "license": "MIT",
   "author": "Joshua Reilly",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "./dist/flat-slider.cjs",
   "module": "./dist/flat-slider.js",
   "types": "./dist/flat-slider.d.ts",


### PR DESCRIPTION
### [0.0.4](https://github.com/ulic75/flat-slider/compare/v0.0.3...v0.0.4) (2022-03-12)

### Changes

- correct issue with package.json exports